### PR TITLE
add back missing import for LooseVersion in MCR easyblock

### DIFF
--- a/easybuild/easyblocks/m/mcr.py
+++ b/easybuild/easyblocks/m/mcr.py
@@ -37,6 +37,7 @@ import re
 import os
 import shutil
 import stat
+from distutils.version import LooseVersion
 
 from easybuild.easyblocks.generic.packedbinary import PackedBinary
 from easybuild.framework.easyconfig import CUSTOM


### PR DESCRIPTION
for https://github.com/hpcugent/easybuild-easyblocks/pull/1056